### PR TITLE
Efficient Change in Floyd-Warshall Algorithm

### DIFF
--- a/Floyd-Warshall.java
+++ b/Floyd-Warshall.java
@@ -77,3 +77,17 @@ class AllPairShortestPath
         a.floydWarshall(graph);
     }
 }
+
+
+/*
+#include <limits.h>
+
+#define INF INT_MAX
+..........................
+if ( dist[i][k] != INF && 
+     dist[k][j] != INF && 
+     dist[i][k] + dist[k][j] < dist[i][j]
+    )
+ dist[i][j] = dist[i][k] + dist[k][j];
+...........................
+*/


### PR DESCRIPTION
The above program only prints the shortest distances. We can modify the solution to print the shortest paths also by storing the predecessor information in a separate 2-D matrix.
Also, the value of INF can be taken as INT_MAX from limits.h to make sure that we handle maximum possible value. When we take INF as INT_MAX, we need to change the if condition in the above program to avoid arithmetic overflow.